### PR TITLE
fix arcTo function

### DIFF
--- a/context.js
+++ b/context.js
@@ -661,7 +661,7 @@ export default (function () {
     /**
      * Adds the arcTo to the current path
      *
-     * @see http://www.w3.org/TR/2015/WD-2dcontext-20150514/#dom-context-2d-arcto
+     * @see https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-arcto
      */
     Context.prototype.arcTo = function (x1, y1, x2, y2, radius) {
         // Let the point (x0, y0) be the last point in the subpath.
@@ -699,7 +699,6 @@ export default (function () {
             this.lineTo(x1, y1);
             return;
         }
-
         // Otherwise, let The Arc be the shortest arc given by circumference of the circle that has radius radius,
         // and that has one point tangent to the half-infinite line that crosses the point (x0, y0) and ends at the point (x1, y1),
         // and that has a different point tangent to the half-infinite line that ends at the point (x1, y1), and crosses the point (x2, y2).
@@ -707,7 +706,7 @@ export default (function () {
 
         // note that both vectors are unit vectors, so the length is 1
         var cos = (unit_vec_p1_p0[0] * unit_vec_p1_p2[0] + unit_vec_p1_p0[1] * unit_vec_p1_p2[1]);
-        var theta = Math.acos(Math.abs(cos));
+        var theta = Math.acos(cos);
 
         // Calculate origin
         var unit_vec_p1_origin = normalize([

--- a/context.js
+++ b/context.js
@@ -931,7 +931,7 @@ export default (function () {
                 "font-weight": style.fontWeight,
 
                 // canvas doesn't support underline natively, but we do :)
-                "text-decoration": this.__fontUnderline,
+                //"text-decoration": this.__fontUnderline, //its never set and ends up as "undefined" in svg.
                 "x": x,
                 "y": y,
                 "text-anchor": getTextAnchor(this.textAlign),

--- a/test/tests/arcTo2.js
+++ b/test/tests/arcTo2.js
@@ -1,7 +1,24 @@
 export default function arcTo(ctx) {
+    let p0=[0,300];
+    let p1=[250,20];
+    let p2=[500,300];
+    let p3=[250,200];
+    let r = 100;
     ctx.beginPath();
-    ctx.moveTo(100, 225);             // P0
-    ctx.arcTo(300, 25, 500, 225, 75); // P1, P2 and the radius
-    ctx.lineTo(500, 225);             // P2
+
+    ctx.moveTo(p0[0],p0[1]);               // P0
+    ctx.arcTo(p1[0],p1[1], p2[0],p2[1], r); // P1, P2 and the radius
+    ctx.lineTo(p2[0],p2[1]);
+    ctx.moveTo(p0[0],p0[1]);
+    ctx.lineTo(p1[0],p1[1], p2[0],p2[1]);
+    ctx.lineTo(p2[0],p2[1]);
+
+    ctx.moveTo(p0[0],p0[1]);               // P0
+    ctx.arcTo(p3[0],p3[1], p2[0],p2[1], r); // P3, P2 and the radius
+    ctx.lineTo(p2[0],p2[1]);
+    ctx.moveTo(p0[0],p0[1]);
+    ctx.lineTo(p3[0],p3[1], p2[0],p2[1]);
+    ctx.lineTo(p2[0],p2[1]);
+
     ctx.stroke();
 };


### PR DESCRIPTION
This is the code that didn't work. 
```
let size=500;
let x1=0;
let x2=size/2;
let x3=size;
let y1=size/3*2;
let y3=size/3*2;
let y2=size/2;

ctx.beginPath();
ctx.moveTo(x1, y1);
ctx.arcTo(x2, y2, x3, y3, 200);
ctx.lineTo(x3, y3);
ctx.moveTo(x1, y1);
ctx.lineTo(x2, y2);
ctx.lineTo(x3, y3);
ctx.stroke();
```
![image](https://user-images.githubusercontent.com/4696503/225940628-7fe56fb4-04d8-460f-8266-86382f1f7695.png)
